### PR TITLE
Mover carga de archivo al panel de filtros

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,28 +32,14 @@ body {
     align-items: center;
 }
 
-.top-container, main, footer {
+header, main, footer {
     width: 100%;
     max-width: 1600px;
 }
 
-.top-container {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 30px;
-}
-
-.file-loader-card {
-    background-color: var(--card-background);
-    padding: 20px;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow-medium);
-}
-
 header {
-    flex-grow: 1;
     text-align: center;
+    margin-bottom: 30px;
 }
 
 h1 {
@@ -120,6 +106,13 @@ h1 {
 .filter-group label {
     font-weight: 600;
     color: #2d3748;
+    font-size: 0.9rem;
+}
+
+.filter-group input[type="file"] {
+    padding: 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
     font-size: 0.9rem;
 }
 
@@ -429,15 +422,9 @@ footer {
     </style>
 </head>
 <body>
-    <div class="top-container">
-        <div class="file-loader-card">
-            <label for="csvFileInput">Cargar archivo CSV/XLSX:</label>
-            <input type="file" id="csvFileInput" accept=".csv, .xlsx, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel">
-        </div>
-        <header>
-            <h1>Dashboard de Control de Plagas</h1>
-        </header>
-    </div>
+    <header>
+        <h1>Dashboard de Control de Plagas</h1>
+    </header>
 
     <main>
         <section id="kpis" class="kpi-container">
@@ -469,6 +456,11 @@ footer {
             <div class="filter-bar">
                 <button id="filter-totales" class="filter-button active">Totales</button>
                 <button id="filter-corregidos" class="filter-button">Corregidos</button>
+            </div>
+
+            <div class="filter-group">
+                <label for="csvFileInput">Cargar archivo CSV/XLSX:</label>
+                <input type="file" id="csvFileInput" accept=".csv, .xlsx, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel">
             </div>
 
             <!-- Nuevos desplegables personalizados -->
@@ -903,6 +895,9 @@ function initMap() {
             }
             return row;
         });
+
+        selectedDistricts = [];
+        selectedBarrios = [];
 
         populateFilters();
         


### PR DESCRIPTION
## Summary
- Coloca la carga de archivo dentro de la tarjeta de filtros y elimina el contenedor superior
- El encabezado ocupa todo el ancho disponible
- Al cargar datos se rellenan los filtros de distrito y barrio desde valores únicos

## Testing
- `npm test` *(falla: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada0eb393883338238c7fbd857a545